### PR TITLE
Add cuda6 conda environment

### DIFF
--- a/cuda6.yml
+++ b/cuda6.yml
@@ -1,0 +1,25 @@
+name: cuda6
+channels:
+  - pytorch
+  - dglteam
+  - conda-forge
+dependencies:
+  - python=3.9
+  - numpy
+  - pandas
+  - scipy
+  - matplotlib
+  - seaborn
+  - scikit-learn
+  - pytorch
+  - torchvision
+  - cudatoolkit
+  - dgl
+  - h5py
+  - pillow
+  - opencv
+  - pip
+  - pip:
+    - timm
+    - transformers
+


### PR DESCRIPTION
## Summary
- add `cuda6.yml` to recreate missing cuda6 conda environment

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68545f1a5de08325ae4b5b7620050f2b